### PR TITLE
feat: add readonly input for displaying errors in URL form

### DIFF
--- a/ui/templates/index.html
+++ b/ui/templates/index.html
@@ -70,6 +70,10 @@
               <label for="url">URL:</label>
               <input type="url" id="url" required />
             </div>
+            <div class="form-group">
+              <label for="errors">Errors:</label>
+              <input type="number" id="errors" readonly />
+            </div>
             <div class="form-actions">
               <button type="submit" class="btn btn-save">Save</button>
               <button type="button" class="btn btn-cancel" id="cancelBtn">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a read-only "Errors" numeric field to the add/edit URL modal form, allowing users to view the number of errors associated with a URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->